### PR TITLE
Improve logging for troubleshooting device discovery

### DIFF
--- a/custom_components/rtl_433_discoverandsubmit/__init__.py
+++ b/custom_components/rtl_433_discoverandsubmit/__init__.py
@@ -1,10 +1,13 @@
 """Home Assistant integration for rtl_433 device discovery."""
 
 from collections import defaultdict
+import logging
 
 from .const import DOMAIN, DATA_DEVICES, DATA_PENDING
 from .discovery import DiscoveryManager
 from .decode import parse_mqtt_message
+
+_LOGGER = logging.getLogger(__name__)
 
 class MQTTListener:
     """Simple MQTT listener stub."""
@@ -16,21 +19,28 @@ class MQTTListener:
 
     async def start(self):
         self._running = True
+        _LOGGER.debug("MQTT listener starting with config: %s", self.config)
         # Real implementation would connect to MQTT broker here
 
     async def stop(self):
         self._running = False
+        _LOGGER.debug("MQTT listener stopped")
         # Real implementation would disconnect here
 
     async def simulate_message(self, topic, payload):
         """Helper for tests to feed a message."""
         if self._running:
+            _LOGGER.debug("Simulating MQTT message on %s: %s", topic, payload)
             device = parse_mqtt_message(topic, payload)
             if device:
+                _LOGGER.debug("Parsed device from MQTT message: %s", device)
                 await self._callback(device)
+            else:
+                _LOGGER.debug("Message on %s did not produce a device", topic)
 
 async def async_setup(hass, config):
     hass.data.setdefault(DOMAIN, defaultdict(dict))
+    _LOGGER.debug("Setting up integration domain storage")
     return True
 
 async def async_setup_entry(hass, entry):
@@ -41,11 +51,13 @@ async def async_setup_entry(hass, entry):
     discovery = DiscoveryManager(hass, entry.entry_id)
 
     async def handle(payload):
+        _LOGGER.debug("Handling incoming payload: %s", payload)
         await discovery.handle_message(payload)
 
     listener = MQTTListener(entry.data, handle)
     data["listener"] = listener
     await listener.start()
+    _LOGGER.debug("Listener started for entry %s", entry.entry_id)
     entry.async_on_unload(listener.stop)
     return True
 
@@ -53,4 +65,5 @@ async def async_unload_entry(hass, entry):
     data = hass.data[DOMAIN].pop(entry.entry_id, None)
     if data and "listener" in data:
         await data["listener"].stop()
+        _LOGGER.debug("Listener stopped for entry %s", entry.entry_id)
     return True

--- a/custom_components/rtl_433_discoverandsubmit/config_flow.py
+++ b/custom_components/rtl_433_discoverandsubmit/config_flow.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import logging
 import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.core import callback
 
 from . import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class Rtl433ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -19,8 +22,10 @@ class Rtl433ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(self, user_input=None):
         if user_input is not None:
+            _LOGGER.debug("User provided MQTT settings: %s", user_input)
             return self.async_create_entry(title="rtl_433 MQTT", data=user_input)
 
+        _LOGGER.debug("Showing initial configuration form")
         return self.async_show_form(
             step_id="user",
             data_schema=vol.Schema(
@@ -36,18 +41,21 @@ class Rtl433ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_device(self, discovery_info):
         """Handle a newly discovered device."""
+        _LOGGER.debug("Device discovered: %s", discovery_info)
         self._device_data = discovery_info
         return await self.async_step_confirm()
 
     async def async_step_confirm(self, user_input=None):
         if user_input is not None:
             if user_input.get("use_device"):
+                _LOGGER.debug("User accepted device %s", self._device_data)
                 return self.async_create_entry(
                     title=self._device_data["device"].get("model", "rtl_433"),
                     data=self._device_data,
                 )
+            _LOGGER.debug("User declined device %s", self._device_data)
             return self.async_abort(reason="user_declined")
-
+        _LOGGER.debug("Asking user to confirm device %s", self._device_data)
         return self.async_show_form(
             step_id="confirm",
             data_schema=vol.Schema({vol.Required("use_device", default=True): bool}),
@@ -67,8 +75,10 @@ class Rtl433OptionsFlowHandler(config_entries.OptionsFlow):
 
     async def async_step_init(self, user_input=None):
         if user_input is not None:
+            _LOGGER.debug("Options updated: %s", user_input)
             return self.async_create_entry(title="", data=user_input)
 
+        _LOGGER.debug("Showing options flow form")
         return self.async_show_form(
             step_id="init",
             data_schema=vol.Schema({vol.Optional("topic", default=self.config_entry.options.get("topic", self.config_entry.data.get("topic"))): str}),

--- a/custom_components/rtl_433_discoverandsubmit/decode.py
+++ b/custom_components/rtl_433_discoverandsubmit/decode.py
@@ -7,10 +7,13 @@ from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
+_LOGGER.debug("Loading device mappings for rtl_433 integration")
+
 # Load device mappings from the package data bundled with the integration
 try:
     mappings_bytes = pkgutil.get_data(__package__, 'config/device_mappings.json')
     DEVICE_MAPPINGS = json.loads(mappings_bytes.decode()) if mappings_bytes else {}
+    _LOGGER.debug("Loaded %d device mappings", len(DEVICE_MAPPINGS))
 except Exception as err:
     _LOGGER.error("Failed to load device mappings: %s", err)
     DEVICE_MAPPINGS = {}
@@ -18,6 +21,7 @@ except Exception as err:
 
 def parse_mqtt_message(topic: str, payload: str) -> Optional[Dict[str, Any]]:
     """Parse an MQTT message published by rtl_433."""
+    _LOGGER.debug("Parsing MQTT message on topic %s: %s", topic, payload)
     try:
         data = json.loads(payload)
     except json.JSONDecodeError:
@@ -41,4 +45,5 @@ def parse_mqtt_message(topic: str, payload: str) -> Optional[Dict[str, Any]]:
         'raw': data,
         'sensors': {k: data[k] for k in DEVICE_MAPPINGS if k in data},
     }
+    _LOGGER.debug("Decoded device data: %s", device)
     return device

--- a/custom_components/rtl_433_discoverandsubmit/discovery.py
+++ b/custom_components/rtl_433_discoverandsubmit/discovery.py
@@ -1,7 +1,10 @@
 """Device discovery helper for rtl_433 integration."""
 
 import asyncio
+import logging
 from .const import DOMAIN, DATA_DEVICES, DATA_PENDING
+
+_LOGGER = logging.getLogger(__name__)
 
 class DiscoveryManager:
     """Manage discovered devices and trigger config flows."""
@@ -14,9 +17,12 @@ class DiscoveryManager:
 
     async def handle_message(self, payload):
         device_id = f"{payload.get('model')}_{payload.get('id', 'unknown')}"
+        _LOGGER.debug("Received payload for device %s: %s", device_id, payload)
         if device_id in self.known or device_id in self.pending:
+            _LOGGER.debug("Device %s already known or pending", device_id)
             return
         self.pending[device_id] = payload
+        _LOGGER.debug("Triggering config flow for %s", device_id)
         await self.hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": "device"},


### PR DESCRIPTION
## Summary
- add debug logs when MQTT listener starts, handles messages and unloads
- log MQTT payload parsing and device discovery steps
- include debug statements in config flow for user and device actions

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*