### PR TITLE
Implement MQTT listener

### DIFF
--- a/custom_components/rtl_433_discoverandsubmit/__init__.py
+++ b/custom_components/rtl_433_discoverandsubmit/__init__.py
@@ -2,6 +2,11 @@
 
 from collections import defaultdict
 import logging
+import asyncio
+try:
+    import paho.mqtt.client as mqtt
+except Exception:  # pragma: no cover - optional dependency may be missing
+    mqtt = None
 
 from .const import DOMAIN, DATA_DEVICES, DATA_PENDING
 from .discovery import DiscoveryManager
@@ -10,22 +15,61 @@ from .decode import parse_mqtt_message
 _LOGGER = logging.getLogger(__name__)
 
 class MQTTListener:
-    """Simple MQTT listener stub."""
+    """Listen to MQTT messages from rtl_433."""
 
     def __init__(self, config, message_callback):
         self.config = config
         self._callback = message_callback
         self._running = False
+        self._client = None
+        self._loop = None
 
     async def start(self):
+        """Connect to the MQTT broker and begin listening."""
+        if mqtt is None:
+            _LOGGER.error("paho-mqtt is required for MQTT listener but not installed")
+            return
+
         self._running = True
+        self._loop = asyncio.get_running_loop()
         _LOGGER.debug("MQTT listener starting with config: %s", self.config)
-        # Real implementation would connect to MQTT broker here
+
+        def on_connect(client, userdata, flags, rc):
+            _LOGGER.debug("MQTT connected with result code: %s", rc)
+            client.subscribe(self.config.get("topic", "rtl_433/+/events"))
+
+        def on_message(client, userdata, msg):
+            if not self._running:
+                return
+            payload = msg.payload.decode()
+            _LOGGER.debug("Received MQTT message on %s: %s", msg.topic, payload)
+            device = parse_mqtt_message(msg.topic, payload)
+            if device:
+                _LOGGER.debug("Parsed device from MQTT message: %s", device)
+                asyncio.run_coroutine_threadsafe(
+                    self._callback(device), self._loop
+                )
+
+        self._client = mqtt.Client()
+        username = self.config.get("mqtt_username")
+        password = self.config.get("mqtt_password")
+        if username or password:
+            self._client.username_pw_set(username, password)
+        self._client.on_connect = on_connect
+        self._client.on_message = on_message
+
+        server = self.config.get("mqtt_server", "localhost")
+        port = int(self.config.get("mqtt_port", 1883))
+        self._client.connect_async(server, port)
+        self._client.loop_start()
 
     async def stop(self):
+        """Stop listening and disconnect from the broker."""
         self._running = False
+        if self._client:
+            self._client.loop_stop()
+            self._client.disconnect()
         _LOGGER.debug("MQTT listener stopped")
-        # Real implementation would disconnect here
 
     async def simulate_message(self, topic, payload):
         """Helper for tests to feed a message."""

--- a/custom_components/rtl_433_discoverandsubmit/manifest.json
+++ b/custom_components/rtl_433_discoverandsubmit/manifest.json
@@ -5,6 +5,8 @@
     "documentation": "https://example.com",
     "dependencies": [],
     "codeowners": [],
-    "requirements": [],
+    "requirements": [
+        "paho-mqtt"
+    ],
     "config_flow": true
 }


### PR DESCRIPTION
## Summary
- implement MQTTListener to connect with paho-mqtt
- add optional dependency handling for missing paho-mqtt
- ensure paho-mqtt is listed as a Home Assistant requirement

## Testing
- `python -m unittest tests/test_decode.py -v`
- `python -m unittest tests/test_discovery.py -v`
