### PR TITLE
Improve device discovery UX

### DIFF
--- a/custom_components/rtl_433_discoverandsubmit/discovery.py
+++ b/custom_components/rtl_433_discoverandsubmit/discovery.py
@@ -25,6 +25,12 @@ class DiscoveryManager:
         _LOGGER.debug("Triggering config flow for %s", device_id)
         await self.hass.config_entries.flow.async_init(
             DOMAIN,
-            context={"source": "device"},
+            context={
+                "source": "device",
+                "title_placeholders": {
+                    "model": payload.get("model", "unknown"),
+                    "id": payload.get("id", "unknown"),
+                },
+            },
             data={"entry_id": self.entry_id, "device": payload},
         )


### PR DESCRIPTION
## Summary
- clarify the device discovery card by setting title placeholders when triggering the flow
- simplify the confirmation step so it just has an "Add" option

## Testing
- `python -m unittest tests/test_decode.py -v`
- `python -m unittest tests/test_discovery.py -v`
