### PR TITLE
Fix device rediscovery and naming

### DIFF
--- a/custom_components/rtl_433_discoverandsubmit/decode.py
+++ b/custom_components/rtl_433_discoverandsubmit/decode.py
@@ -36,7 +36,8 @@ def parse_mqtt_message(topic: str, payload: str) -> Optional[Dict[str, Any]]:
             data.setdefault('id', parts[3])
         elif len(parts) >= 3:
             data.setdefault('model', parts[1])
-            data.setdefault('id', parts[2])
+            if parts[2] != 'events':
+                data.setdefault('id', parts[2])
 
     device = {
         'model': data.get('model'),

--- a/tests/test_decode.py
+++ b/tests/test_decode.py
@@ -12,5 +12,13 @@ class DecodeMessageTest(unittest.TestCase):
         self.assertIn('temperature_C', result['sensors'])
         self.assertEqual(result['sensors']['temperature_C'], 23)
 
+    def test_parse_message_ignores_events_suffix(self):
+        topic = "rtl_433/some_model/events"
+        payload = '{"id": 99, "temperature_C": 20}'
+        result = parse_mqtt_message(topic, payload)
+        self.assertEqual(result['model'], 'some_model')
+        # id should come from payload, not the literal word 'events'
+        self.assertEqual(result['id'], 99)
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -39,5 +39,17 @@ class DiscoveryManagerTest(unittest.TestCase):
         asyncio.run(manager.handle_message(payload))
         self.assertEqual(len(hass.config_entries.flow.inits), 1)
 
+    def test_device_not_rediscovered_after_add(self):
+        hass = FakeHass()
+        manager = DiscoveryManager(hass, "entry")
+        payload = {"model": "test", "id": 2}
+        asyncio.run(manager.handle_message(payload))
+        device_id = "test_2"
+        # Simulate user accepting the device
+        hass.data[DOMAIN]["entry"][DATA_DEVICES][device_id] = payload
+        hass.data[DOMAIN]["entry"][DATA_PENDING].pop(device_id, None)
+        asyncio.run(manager.handle_message(payload))
+        self.assertEqual(len(hass.config_entries.flow.inits), 1)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- avoid misidentifying devices whose topics end with `/events`
- test that `/events` topics get ID from payload
- test that accepted devices aren't rediscovered

## Testing
- `PYTHONPATH=. python tests/test_config_flow.py && PYTHONPATH=. python tests/test_discovery.py && PYTHONPATH=. python tests/test_decode.py`