### PR TITLE
Add flow title translation

### DIFF
--- a/custom_components/rtl_433_discoverandsubmit/translations/en.json
+++ b/custom_components/rtl_433_discoverandsubmit/translations/en.json
@@ -1,5 +1,6 @@
 {
     "config": {
+        "flow_title": "{model} {id}",
         "step": {
             "confirm": {
                 "title": "Add {model} {id}",


### PR DESCRIPTION
## Summary
- fix translation so device names appear in integration discovery

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*