### PR TITLE
Add ignore button for discovered devices

### DIFF
--- a/custom_components/rtl_433_discoverandsubmit/discovery.py
+++ b/custom_components/rtl_433_discoverandsubmit/discovery.py
@@ -26,7 +26,7 @@ class DiscoveryManager:
         await self.hass.config_entries.flow.async_init(
             DOMAIN,
             context={
-                "source": "device",
+                "source": "mqtt",
                 "title_placeholders": {
                     "model": payload.get("model", "unknown"),
                     "id": payload.get("id", "unknown"),

--- a/custom_components/rtl_433_discoverandsubmit/translations/en.json
+++ b/custom_components/rtl_433_discoverandsubmit/translations/en.json
@@ -7,5 +7,8 @@
                 "description": "Discovered device \"{model}\" with id {id}. Sensors: {sensors}. Add to Home Assistant?"
             }
         }
+    },
+    "abort": {
+        "user_declined": "Device was ignored"
     }
 }

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -29,6 +29,7 @@ class DiscoveryManagerTest(unittest.TestCase):
         self.assertEqual(len(hass.config_entries.flow.inits), 1)
         domain, context, data = hass.config_entries.flow.inits[0]
         self.assertEqual(domain, DOMAIN)
+        self.assertEqual(context.get("source"), "mqtt")
         self.assertEqual(data["device"], payload)
 
     def test_duplicate_device_no_flow(self):


### PR DESCRIPTION
## Summary
- trigger device flows with MQTT discovery context
- show a message when a device is ignored
- expect MQTT as the source in tests

## Testing
- `python -m unittest discover -s tests`