### PR TITLE
Persist devices

### DIFF
--- a/custom_components/rtl_433_discoverandsubmit/__init__.py
+++ b/custom_components/rtl_433_discoverandsubmit/__init__.py
@@ -8,7 +8,7 @@ try:
 except Exception:  # pragma: no cover - optional dependency may be missing
     mqtt = None
 
-from .const import DOMAIN, DATA_DEVICES, DATA_PENDING
+from .const import DOMAIN, DATA_DEVICES, DATA_PENDING, OPTION_DEVICES
 from .discovery import DiscoveryManager
 from .decode import parse_mqtt_message
 
@@ -89,7 +89,7 @@ async def async_setup(hass, config):
 
 async def async_setup_entry(hass, entry):
     data = hass.data[DOMAIN][entry.entry_id]
-    data[DATA_DEVICES] = {}
+    data[DATA_DEVICES] = entry.options.get(OPTION_DEVICES, {})
     data[DATA_PENDING] = {}
 
     discovery = DiscoveryManager(hass, entry.entry_id)

--- a/custom_components/rtl_433_discoverandsubmit/config_flow.py
+++ b/custom_components/rtl_433_discoverandsubmit/config_flow.py
@@ -8,7 +8,7 @@ from homeassistant import config_entries
 from homeassistant.core import callback
 
 from . import DOMAIN
-from .const import DATA_DEVICES, DATA_PENDING
+from .const import DATA_DEVICES, DATA_PENDING, OPTION_DEVICES
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -81,6 +81,13 @@ class Rtl433ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             pending = self.hass.data[DOMAIN][entry_id][DATA_PENDING]
             _LOGGER.debug("User accepted device %s", self._device_data)
             self.hass.data[DOMAIN][entry_id][DATA_DEVICES][device_id] = device
+            entry = self.hass.config_entries.async_get_entry(entry_id)
+            stored = dict(entry.options.get(OPTION_DEVICES, {}))
+            stored[device_id] = device
+            self.hass.config_entries.async_update_entry(
+                entry,
+                options={**entry.options, OPTION_DEVICES: stored},
+            )
             pending.pop(device_id, None)
             return self.async_create_entry(
                 title=self._device_title(),

--- a/custom_components/rtl_433_discoverandsubmit/const.py
+++ b/custom_components/rtl_433_discoverandsubmit/const.py
@@ -3,3 +3,4 @@
 DOMAIN = "rtl_433_discoverandsubmit"
 DATA_DEVICES = "devices"
 DATA_PENDING = "pending"
+OPTION_DEVICES = "devices"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -33,6 +33,21 @@ config_entries.ConfigFlow = FakeConfigFlow
 config_entries.OptionsFlow = FakeOptionsFlow
 ha.config_entries = config_entries
 
+class FakeEntry:
+    def __init__(self, entry_id="entry"):
+        self.entry_id = entry_id
+        self.data = {}
+        self.options = {}
+
+class FakeConfigEntriesManager:
+    def __init__(self, entry):
+        self._entry = entry
+    def async_get_entry(self, entry_id):
+        return self._entry
+    def async_update_entry(self, entry, data=None, options=None):
+        if options is not None:
+            entry.options = options
+
 core = types.ModuleType('core')
 core.callback = lambda func: func
 ha.core = core
@@ -42,11 +57,18 @@ sys.modules['homeassistant.config_entries'] = config_entries
 sys.modules['homeassistant.core'] = core
 
 from custom_components.rtl_433_discoverandsubmit.config_flow import Rtl433ConfigFlow
-from custom_components.rtl_433_discoverandsubmit.const import DOMAIN, DATA_DEVICES, DATA_PENDING
+from custom_components.rtl_433_discoverandsubmit.const import (
+    DOMAIN,
+    DATA_DEVICES,
+    DATA_PENDING,
+    OPTION_DEVICES,
+)
 
 class FakeHass:
     def __init__(self):
         self.data = {DOMAIN: {'entry': {DATA_DEVICES: {}, DATA_PENDING: {}}}}
+        self.entry = FakeEntry("entry")
+        self.config_entries = FakeConfigEntriesManager(self.entry)
 
 class ConfigFlowTitleTest(unittest.TestCase):
     def test_flow_title_after_device(self):
@@ -56,6 +78,19 @@ class ConfigFlowTitleTest(unittest.TestCase):
         discovery = {'entry_id': 'entry', 'device': {'model': 'test', 'id': 1}}
         asyncio.run(flow.async_step_device(discovery))
         self.assertEqual(flow.flow_title, 'test 1')
+
+class ConfigFlowPersistTest(unittest.TestCase):
+    def test_confirm_persists_device(self):
+        hass = FakeHass()
+        flow = Rtl433ConfigFlow()
+        FakeConfigFlow.__init__(flow)
+        flow.hass = hass
+        discovery = {'entry_id': 'entry', 'device': {'model': 'test', 'id': 2}}
+        asyncio.run(flow.async_step_device(discovery))
+        result = asyncio.run(flow.async_step_confirm(user_input={}))
+        devices = hass.entry.options.get(OPTION_DEVICES)
+        self.assertIn('test_2', devices)
+        self.assertEqual(result['type'], 'create_entry')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- keep track of accepted devices in config entry options
- load stored device list on setup
- test persistence logic

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885d02ca0008332970d00a6e5df26c3