### PR TITLE
Fix packaging for custom_components data files

### DIFF
--- a/custom_components/__init__.py
+++ b/custom_components/__init__.py
@@ -1,0 +1,1 @@
+# Package marker for setuptools


### PR DESCRIPTION
## Summary
- include the `custom_components` package so device mappings are installed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885e52c1cdc8332b8be6bea508e7249